### PR TITLE
Fix issue #5: Add a telegram interface

### DIFF
--- a/telegram_interface.py
+++ b/telegram_interface.py
@@ -1,0 +1,26 @@
+import telegram
+from telegram.ext import Updater, CommandHandler, MessageHandler, Filters
+
+class TelegramBot:
+    def __init__(self, token):
+        self.updater = Updater(token, use_context=True)
+        self.dispatcher = self.updater.dispatcher
+
+    def start(self, update, context):
+        context.bot.send_message(chat_id=update.effective_chat.id, text="Hello! I am a bot.")
+
+    def echo(self, update, context):
+        context.bot.send_message(chat_id=update.effective_chat.id, text=update.message.text)
+
+    def run(self):
+        start_handler = CommandHandler('start', self.start)
+        echo_handler = MessageHandler(Filters.text & (~Filters.command), self.echo)
+        self.dispatcher.add_handler(start_handler)
+        self.dispatcher.add_handler(echo_handler)
+        self.updater.start_polling()
+        self.updater.idle()
+
+if __name__ == '__main__':
+    TOKEN = 'YOUR_TELEGRAM_BOT_TOKEN'
+    bot = TelegramBot(TOKEN)
+    bot.run()

--- a/test/test_telegram_interface.py
+++ b/test/test_telegram_interface.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import MagicMock
+from telegram_interface import TelegramBot
+
+class TestTelegramBot(unittest.TestCase):
+    def setUp(self):
+        self.token = 'fake-token'
+        self.bot = TelegramBot(self.token)
+        self.bot.updater = MagicMock()
+        self.bot.dispatcher = MagicMock()
+
+    def test_start(self):
+        update = MagicMock()
+        context = MagicMock()
+        self.bot.start(update, context)
+        context.bot.send_message.assert_called_once_with(chat_id=update.effective_chat.id, text="Hello! I am a bot.")
+
+    def test_echo(self):
+        update = MagicMock()
+        update.message.text = "Hello"
+        context = MagicMock()
+        self.bot.echo(update, context)
+        context.bot.send_message.assert_called_once_with(chat_id=update.effective_chat.id, text="Hello")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #5.

The issue was to add the Python code required for a very basic Telegram interface. The changes made include the creation of a new Python file, `telegram_interface.py`, which defines a `TelegramBot` class. This class uses the `python-telegram-bot` library to implement a basic bot with a `/start` command and an echo functionality. The bot is set up to start polling for updates and handle messages appropriately. Additionally, a test file `test_telegram_interface.py` was created to verify the functionality of the `start` and `echo` methods using unit tests with mocked objects. These changes directly address the issue by providing the necessary code for a basic Telegram interface and include tests to ensure the functionality works as expected.

`<<SOLVER: 0xDCbA0A20d519813a16F73B5e264206E82691B4bA>>`