### PR TITLE
Fix issue #8: Basic Calendar Event Data Model & Logic

### DIFF
--- a/calendar_event.py
+++ b/calendar_event.py
@@ -1,0 +1,29 @@
+import sqlite3
+
+class CalendarEvent:
+    def __init__(self, title, start_time, end_time, location=None, description=None):
+        self.title = title
+        self.start_time = start_time
+        self.end_time = end_time
+        self.location = location
+        self.description = description
+
+    def save_to_db(self, db_path):
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                start_time TEXT NOT NULL,
+                end_time TEXT NOT NULL,
+                location TEXT,
+                description TEXT
+            )
+        ''')
+        cursor.execute('''
+            INSERT INTO events (title, start_time, end_time, location, description)
+            VALUES (?, ?, ?, ?, ?)
+        ''', (self.title, self.start_time, self.end_time, self.location, self.description))
+        conn.commit()
+        conn.close()

--- a/test_calendar_event.py
+++ b/test_calendar_event.py
@@ -1,0 +1,38 @@
+import unittest
+import sqlite3
+from calendar_event import CalendarEvent
+
+class TestCalendarEvent(unittest.TestCase):
+    def setUp(self):
+        self.db_path = 'test_calendar.db'
+        self.event = CalendarEvent(
+            title='Meeting',
+            start_time='2023-03-01 10:00:00',
+            end_time='2023-03-01 11:00:00',
+            location='Conference Room',
+            description='Discuss project updates'
+        )
+
+    def tearDown(self):
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute('DROP TABLE IF EXISTS events')
+        conn.commit()
+        conn.close()
+
+    def test_save_to_db(self):
+        self.event.save_to_db(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute('SELECT * FROM events')
+        events = cursor.fetchall()
+        conn.close()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0][1], 'Meeting')
+        self.assertEqual(events[0][2], '2023-03-01 10:00:00')
+        self.assertEqual(events[0][3], '2023-03-01 11:00:00')
+        self.assertEqual(events[0][4], 'Conference Room')
+        self.assertEqual(events[0][5], 'Discuss project updates')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #8.

The issue was to write basic data classes for an iOS-like calendar entry to be stored in a local SQLite database. The changes made include the creation of a `CalendarEvent` class in `calendar_event.py` with attributes for title, start time, end time, location, and description. The class includes a method `save_to_db` that connects to a SQLite database, creates an `events` table if it doesn't exist, and inserts the event data into this table. Additionally, a test suite `test_calendar_event.py` was created using the `unittest` framework. It includes a test case `test_save_to_db` that verifies the event is correctly saved to the database by checking the inserted data. The presence of a test database `test_calendar.db` and the successful execution of the test case indicate that the functionality works as intended. Therefore, the issue has been successfully resolved.

`<<SOLVER: 0xDCbA0A20d519813a16F73B5e264206E82691B4bA>>`